### PR TITLE
Reft 60 view property token details

### DIFF
--- a/frontend/app/property/[id]/details/page.tsx
+++ b/frontend/app/property/[id]/details/page.tsx
@@ -1,0 +1,35 @@
+import PropertyDetail from "@/app/ui/PropertyDetail";
+import React from "react";
+
+const page = () => {
+  const PropertyData = {
+    id: 1,
+    state: "CA",
+    city: `Los Angeles`,
+    street1: `123 Main St`,
+    street2: "",
+    zip: `90000`,
+    value: 500000,
+    tokens: 100,
+    tokenForSale: 10,
+    tokenPrice: 500000 / 100,
+    image: "/images/Dunno.jpg",
+    year: 1949,
+    propType: "Residential",
+    propSubtype: "Single-Family",
+    size: 2100,
+    expense: 1234,
+    income: 12345,
+    sizeValue: 500000 / 2100,
+    owners: "",
+    ownPercent: "",
+    entity: "",
+  };
+  return (
+    <div>
+      <PropertyDetail data={PropertyData} />
+    </div>
+  );
+};
+
+export default page;

--- a/frontend/app/property/[id]/page.tsx
+++ b/frontend/app/property/[id]/page.tsx
@@ -26,8 +26,10 @@ const page = () => {
     entity: "",
   };
   return (
-    <div>
-      <PropertyDetail data={PropertyData} />
+    <div className="flex justify-center items-center h-screen mt-4">
+      <div className="w-1/3">
+        <PropertyDetail data={PropertyData} />
+      </div>
     </div>
   );
 };

--- a/frontend/app/property/search/page.tsx
+++ b/frontend/app/property/search/page.tsx
@@ -13,6 +13,7 @@ interface SearchResultProps {
 }
 
 const SearchResult: React.FC<SearchResultProps> = ({ searchParams }) => {
+  const modalHeader = "Token Details";
   const page = searchParams["page"] ? Number(searchParams["page"]) : 1;
   const per_page = searchParams["per_page"]
     ? Number(searchParams["per_page"])
@@ -79,6 +80,8 @@ const SearchResult: React.FC<SearchResultProps> = ({ searchParams }) => {
                 <ModalComp
                   openModal={openModals[index]}
                   setOpenModal={() => handleCloseModal(index)}
+                  modalHeader={modalHeader}
+                  modalSize="3xl"
                 >
                   <PropertyDetail data={property} />
                 </ModalComp>

--- a/frontend/app/property/search/page.tsx
+++ b/frontend/app/property/search/page.tsx
@@ -1,7 +1,12 @@
-import React from "react";
+"use client";
+import { useState } from "react";
 import PaginationComp from "@/app/ui/Pagination";
 import PropertyCard from "@/app/ui/PropertyCard";
 import SearchNav from "@/app/ui/SearchNav";
+import { PropertyData } from "@/app/ui/CardData";
+import Link from "next/link";
+import ModalComp from "@/app/ui/ModalComp";
+import PropertyDetail from "@/app/ui/PropertyDetail";
 
 interface SearchResultProps {
   searchParams: { [key: string]: string | string[] | undefined };
@@ -19,14 +24,41 @@ const SearchResult: React.FC<SearchResultProps> = ({ searchParams }) => {
     id: index + 1,
     state: "CA",
     city: `Los Angeles ${index + 1}`,
-    street: `${index + 1} Main St`,
+    street1: `${index + 1} Main St`,
+    street2: "",
     zip: `9000${index + 1}`,
+    year: 1900 + (index + 1),
     value: 500000 + (index + 1) * 10000,
     tokens: 100 + index,
     tokenForSale: 10 + index,
     tokenPrice: (500000 + (index + 1) * 10000) / (100 + index),
+    propType: "Residential",
+    propSubtype: "Single Family",
+    size: 1000 + index * 100,
+    owners: "Garry",
+    ownPercent: "100%",
+    entity: "individual",
+    income: 100 + index * 100,
+    expense: 10 + index * 10,
     image: "/images/Dunno.jpg",
+    sizeValue: (500000 + (index + 1) * 10000) / (1000 + index * 100),
   }));
+
+  const [openModals, setOpenModals] = useState<boolean[]>(
+    Array(cardDataArray.length).fill(false)
+  );
+
+  const handleOpenModal = (index: number) => {
+    const newModals = [...openModals];
+    newModals[index] = true;
+    setOpenModals(newModals);
+  };
+
+  const handleCloseModal = (index: number) => {
+    const newModals = [...openModals];
+    newModals[index] = false;
+    setOpenModals(newModals);
+  };
 
   const start = (page - 1) * per_page;
   const end = start + per_page;
@@ -36,17 +68,23 @@ const SearchResult: React.FC<SearchResultProps> = ({ searchParams }) => {
   return (
     <div>
       <SearchNav per_Page={per_page} totalProperties={totalProperties} />
-      <div className="flex justify-center mt-4">
+      <div className="flex justify-center mt-4 mb-24">
         <div className="w-full">
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 max-w-screen-xl mx-auto mt-8">
-            {entries.map((property) => (
-              <div key={property.id} className="border p-4 overflow-x-hidden">
-                {/* Render your property card here */}
-                <PropertyCard data={property} />
+            {entries.map((property, index) => (
+              <div key={property.id} className="p-2 overflow-x-hidden">
+                <button onClick={() => handleOpenModal(index)}>
+                  <PropertyCard data={property} />
+                </button>
+                <ModalComp
+                  openModal={openModals[index]}
+                  setOpenModal={() => handleCloseModal(index)}
+                >
+                  <PropertyDetail data={property} />
+                </ModalComp>
               </div>
             ))}
           </div>
-          <PaginationComp totalPages={Math.ceil(totalProperties / per_page)} />
         </div>
       </div>
     </div>

--- a/frontend/app/ui/BuySellButtons.tsx
+++ b/frontend/app/ui/BuySellButtons.tsx
@@ -1,0 +1,72 @@
+import { Button } from "flowbite-react";
+import React, { useState } from "react";
+import BuySellTokens from "./BuySellTokens";
+import { BuySellData } from "./CardData";
+import ModalComp from "./ModalComp";
+
+interface BuySellButtonsProps {
+  bsTotals: BuySellData;
+}
+
+const BuySellButtons: React.FC<BuySellButtonsProps> = ({ bsTotals }) => {
+  const [openModal, setOpenModal] = useState(false);
+  const [buttonOption, setButtonOption] = useState(false);
+  const [modalHeader, setModalHeader] = useState("");
+  const [totalOption, setTotalOption] = useState(0);
+
+  const handleBuy = () => {
+    setButtonOption(true);
+    setOpenModal(true);
+    setModalHeader("Buy Tokens");
+    setTotalOption(bsTotals.buyTotal);
+  };
+  const handleSell = () => {
+    setButtonOption(false);
+    setOpenModal(true);
+    setModalHeader("Sell Tokens");
+    setTotalOption(bsTotals.sellTotal);
+  };
+
+  return (
+    <div>
+      <ModalComp
+        openModal={openModal}
+        setOpenModal={setOpenModal}
+        modalHeader={modalHeader}
+        modalSize="sm"
+      >
+        <div>
+          {buttonOption ? (
+            <div>
+              <BuySellTokens
+                setOpenModal={setOpenModal}
+                totalOption={totalOption}
+              />
+            </div>
+          ) : (
+            <div>
+              <BuySellTokens
+                setOpenModal={setOpenModal}
+                totalOption={totalOption}
+              />
+            </div>
+          )}
+        </div>
+      </ModalComp>
+      <div className="w-48 flex flex-col justify-center items-center gap-4 shadow-lg shadow-gray-900 rounded-lg">
+        <div>
+          <Button onClick={handleBuy} className="w-32 mt-4">
+            Buy Tokens
+          </Button>
+        </div>
+        <div>
+          <Button onClick={handleSell} className="w-32 mb-4">
+            Sell Tokens
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BuySellButtons;

--- a/frontend/app/ui/BuySellButtons.tsx
+++ b/frontend/app/ui/BuySellButtons.tsx
@@ -6,9 +6,13 @@ import ModalComp from "./ModalComp";
 
 interface BuySellButtonsProps {
   bsTotals: BuySellData;
+  tokenPrice: number;
 }
 
-const BuySellButtons: React.FC<BuySellButtonsProps> = ({ bsTotals }) => {
+const BuySellButtons: React.FC<BuySellButtonsProps> = ({
+  bsTotals,
+  tokenPrice,
+}) => {
   const [openModal, setOpenModal] = useState(false);
   const [buttonOption, setButtonOption] = useState(false);
   const [modalHeader, setModalHeader] = useState("");
@@ -41,6 +45,7 @@ const BuySellButtons: React.FC<BuySellButtonsProps> = ({ bsTotals }) => {
               <BuySellTokens
                 setOpenModal={setOpenModal}
                 totalOption={totalOption}
+                tokenPrice={tokenPrice}
               />
             </div>
           ) : (
@@ -48,6 +53,7 @@ const BuySellButtons: React.FC<BuySellButtonsProps> = ({ bsTotals }) => {
               <BuySellTokens
                 setOpenModal={setOpenModal}
                 totalOption={totalOption}
+                tokenPrice={tokenPrice}
               />
             </div>
           )}

--- a/frontend/app/ui/BuySellTokens.tsx
+++ b/frontend/app/ui/BuySellTokens.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { FloatingLabel, Button } from "flowbite-react";
+
+interface BuySellTokensProps {
+  setOpenModal: (openModal: boolean) => void;
+  totalOption: number;
+}
+
+const BuySellTokens: React.FC<BuySellTokensProps> = ({
+  setOpenModal,
+  totalOption,
+}) => {
+  const handleSubmit = () => {
+    setOpenModal(false);
+  };
+  return (
+    <div className="flex flex-col">
+      <form onSubmit={handleSubmit}>
+        <div className="grid grid-flow-col justify-stretch items-center space-x-4">
+          <div>
+            <FloatingLabel
+              type="number"
+              variant="standard"
+              label="# of Tokens"
+              min="1"
+              max={totalOption.toString()}
+              required
+            />
+          </div>
+          <div className="w-16">{totalOption}</div>
+        </div>
+        <div className="flex justify-center items-center mt-4">
+          <Button type="submit">Confirm</Button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default BuySellTokens;

--- a/frontend/app/ui/BuySellTokens.tsx
+++ b/frontend/app/ui/BuySellTokens.tsx
@@ -1,18 +1,31 @@
 "use client";
 
 import { FloatingLabel, Button } from "flowbite-react";
+import { useState } from "react";
 
 interface BuySellTokensProps {
   setOpenModal: (openModal: boolean) => void;
   totalOption: number;
+  tokenPrice: number;
 }
+
+const formatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
 
 const BuySellTokens: React.FC<BuySellTokensProps> = ({
   setOpenModal,
   totalOption,
+  tokenPrice,
 }) => {
+  const [numberOfTokens, setNumberOfTokens] = useState<number>(1);
   const handleSubmit = () => {
     setOpenModal(false);
+  };
+  const handleTokenChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const inputValue = parseInt(event.target.value);
+    setNumberOfTokens(inputValue);
   };
   return (
     <div className="flex flex-col">
@@ -25,10 +38,15 @@ const BuySellTokens: React.FC<BuySellTokensProps> = ({
               label="# of Tokens"
               min="1"
               max={totalOption.toString()}
+              value={numberOfTokens.toString()}
+              onChange={handleTokenChange}
               required
             />
           </div>
-          <div className="w-16">{totalOption}</div>
+          <div className="w-16"> / {totalOption}</div>
+        </div>
+        <div>
+          Estimated value: {formatter.format(tokenPrice * numberOfTokens)}
         </div>
         <div className="flex justify-center items-center mt-4">
           <Button type="submit">Confirm</Button>

--- a/frontend/app/ui/CardCarousel.tsx
+++ b/frontend/app/ui/CardCarousel.tsx
@@ -1,23 +1,10 @@
 "use client";
 
 import React, { useState } from "react";
-import { Carousel } from "flowbite-react";
+import { Carousel, ModalHeader } from "flowbite-react";
 import PropertyCard from "./PropertyCard";
 import ModalComp from "./ModalComp";
 import PropertyDetail from "@/app/ui/PropertyDetail";
-
-interface CardData {
-  id: number;
-  state: string;
-  city: string;
-  street: string;
-  zip: string;
-  value: number;
-  tokens: number;
-  tokenForSale: number;
-  tokenPrice: number;
-  image: string;
-}
 
 const cardDataArray = Array.from({ length: 12 }, (_, index) => ({
   id: index + 1,
@@ -91,6 +78,8 @@ const CardCarousel: React.FC = () => {
                     key={`modal-${chunkIndex}-${cardIndex}`}
                     openModal={openModals[chunkIndex][cardIndex]}
                     setOpenModal={() => handleCloseModal(chunkIndex, cardIndex)}
+                    modalHeader={"Token Details"}
+                    modalSize="3xl"
                   >
                     <PropertyDetail data={data} />
                   </ModalComp>

--- a/frontend/app/ui/CardCarousel.tsx
+++ b/frontend/app/ui/CardCarousel.tsx
@@ -1,7 +1,10 @@
 "use client";
+
 import React, { useState } from "react";
 import { Carousel } from "flowbite-react";
 import PropertyCard from "./PropertyCard";
+import ModalComp from "./ModalComp";
+import PropertyDetail from "@/app/ui/PropertyDetail";
 
 interface CardData {
   id: number;
@@ -16,17 +19,28 @@ interface CardData {
   image: string;
 }
 
-const cardDataArray: CardData[] = Array.from({ length: 12 }, (_, index) => ({
+const cardDataArray = Array.from({ length: 12 }, (_, index) => ({
   id: index + 1,
   state: "CA",
   city: `Los Angeles ${index + 1}`,
-  street: `${index + 1} Main St`,
+  street1: `${index + 1} Main St`,
+  street2: "",
   zip: `9000${index + 1}`,
+  year: 1900 + (index + 1),
   value: 500000 + (index + 1) * 10000,
   tokens: 100 + index,
   tokenForSale: 10 + index,
   tokenPrice: (500000 + (index + 1) * 10000) / (100 + index),
+  propType: "Residential",
+  propSubtype: "Single Family",
+  size: 1000 + index * 100,
+  owners: "Garry",
+  ownPercent: "100%",
+  entity: "individual",
+  income: 100 + index * 100,
+  expense: 10 + index * 10,
   image: "/images/Dunno.jpg",
+  sizeValue: (500000 + (index + 1) * 10000) / (1000 + index * 100),
 }));
 
 const chunkArray = (arr: any[], size: number) => {
@@ -36,26 +50,50 @@ const chunkArray = (arr: any[], size: number) => {
 };
 
 const CardCarousel: React.FC = () => {
-  const chunkedData = chunkArray(cardDataArray, 3); // Split data into chunks of 3
+  const chunkedData = chunkArray(cardDataArray, 3);
+  const [openModals, setOpenModals] = useState<boolean[][]>(
+    Array(chunkedData.length)
+      .fill([])
+      .map(() => Array(3).fill(false))
+  );
+
+  const handleOpenModal = (chunkIndex: number, cardIndex: number) => {
+    const newModals = [...openModals];
+    newModals[chunkIndex][cardIndex] = true;
+    setOpenModals(newModals);
+  };
+
+  const handleCloseModal = (chunkIndex: number, cardIndex: number) => {
+    const newModals = [...openModals];
+    newModals[chunkIndex][cardIndex] = false;
+    setOpenModals(newModals);
+  };
 
   return (
     <div className="w-full h-screen overflow-hidden flex items-center justify-center">
       <div className="w-full max-w-screen-xl h-full">
-        <Carousel
-          pauseOnHover
-          indicators={false}
-          onSlideChange={(index) => console.log("onSlideChange()", index)}
-        >
-          {chunkedData.map((chunk, index) => (
-            <div key={index} className="flex items-center justify-center">
-              {chunk.map((data, dataIndex) => (
+        <Carousel pauseOnHover indicators={false}>
+          {chunkedData.map((chunk, chunkIndex) => (
+            <div key={chunkIndex} className="flex items-center justify-center">
+              {chunk.map((data, cardIndex) => (
                 <div
                   key={data.id}
                   className={`mx-10 ${
-                    dataIndex !== chunk.length - 1 ? "mr-4" : ""
+                    cardIndex !== chunk.length - 1 ? "mr-4" : ""
                   }`}
                 >
-                  <PropertyCard data={data} />
+                  <button
+                    onClick={() => handleOpenModal(chunkIndex, cardIndex)}
+                  >
+                    <PropertyCard data={data} />
+                  </button>
+                  <ModalComp
+                    key={`modal-${chunkIndex}-${cardIndex}`}
+                    openModal={openModals[chunkIndex][cardIndex]}
+                    setOpenModal={() => handleCloseModal(chunkIndex, cardIndex)}
+                  >
+                    <PropertyDetail data={data} />
+                  </ModalComp>
                 </div>
               ))}
             </div>

--- a/frontend/app/ui/CardCarousel.tsx
+++ b/frontend/app/ui/CardCarousel.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+"use client";
+import React, { useState } from "react";
 import { Carousel } from "flowbite-react";
 import PropertyCard from "./PropertyCard";
 
@@ -46,10 +47,7 @@ const CardCarousel: React.FC = () => {
           onSlideChange={(index) => console.log("onSlideChange()", index)}
         >
           {chunkedData.map((chunk, index) => (
-            <div
-              key={index}
-              className="flex h-full items-center justify-center"
-            >
+            <div key={index} className="flex items-center justify-center">
               {chunk.map((data, dataIndex) => (
                 <div
                   key={data.id}

--- a/frontend/app/ui/CardData.tsx
+++ b/frontend/app/ui/CardData.tsx
@@ -10,3 +10,27 @@ export interface CardData {
   tokenPrice: number;
   image: string;
 }
+
+export interface PropertyData {
+  id: number;
+  state: string;
+  city: string;
+  street1: string;
+  street2: string;
+  zip: string;
+  year: number;
+  value: number;
+  tokens: number;
+  tokenForSale: number;
+  tokenPrice: number;
+  propType: string;
+  propSubtype: string;
+  size: number;
+  owners: string;
+  ownPercent: string;
+  entity: string;
+  income: number;
+  expense: number;
+  image: string;
+  sizeValue: number;
+}

--- a/frontend/app/ui/CardData.tsx
+++ b/frontend/app/ui/CardData.tsx
@@ -34,3 +34,8 @@ export interface PropertyData {
   image: string;
   sizeValue: number;
 }
+
+export interface BuySellData {
+  sellTotal: number;
+  buyTotal: number;
+}

--- a/frontend/app/ui/GalleryComp.tsx
+++ b/frontend/app/ui/GalleryComp.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import Image from "next/image";
+import { PropertyData } from "./CardData";
+
+interface GalleryCompProps {
+  data: PropertyData;
+}
+
+const GalleryComp: React.FC<GalleryCompProps> = ({ data }) => {
+  return (
+    <div className="grid grid-cols-2 gap-2">
+      <div>
+        <Image
+          width={500}
+          height={500}
+          src={data.image}
+          alt="Property Image 1"
+          className="h-auto max-w-full rounded-lg transition duration-150 ease-in-out transform hover:brightness-75"
+        />
+      </div>
+      <div>
+        <Image
+          width={500}
+          height={500}
+          src={data.image}
+          alt="Property Image 1"
+          className="h-auto max-w-full rounded-lg transition duration-150 ease-in-out transform hover:brightness-75"
+        />
+      </div>
+      <div>
+        <Image
+          width={500}
+          height={500}
+          src={data.image}
+          alt="Property Image 1"
+          className="h-auto max-w-full rounded-lg transition duration-150 ease-in-out transform hover:brightness-75"
+        />
+      </div>
+      <div>
+        <Image
+          width={500}
+          height={500}
+          src={data.image}
+          alt="Property Image 1"
+          className="h-auto max-w-full rounded-lg transition duration-150 ease-in-out transform hover:brightness-75"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default GalleryComp;

--- a/frontend/app/ui/ModalComp.tsx
+++ b/frontend/app/ui/ModalComp.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect } from "react";
+
+type ModalProps = {
+  onClose: () => void;
+  children: React.ReactNode;
+};
+
+const ModalComp: React.FC<ModalProps> = ({ onClose, children }) => {
+  useEffect(() => {
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (!(event.target as HTMLElement).closest(".modal-content")) {
+        onClose();
+      }
+    };
+
+    document.addEventListener("mousedown", handleOutsideClick);
+
+    return () => {
+      document.removeEventListener("mousedown", handleOutsideClick);
+    };
+  }, [onClose]);
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center z-50">
+      <div className="fixed inset-0 bg-black opacity-50"></div>
+      <div className="absolute bg-white rounded-lg shadow-lg p-6 modal-content">
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default ModalComp;

--- a/frontend/app/ui/ModalComp.tsx
+++ b/frontend/app/ui/ModalComp.tsx
@@ -1,33 +1,33 @@
 "use client";
 
-import { useEffect } from "react";
+import { Button, Modal, Select } from "flowbite-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
 
-type ModalProps = {
-  onClose: () => void;
+interface ModalCompProps {
   children: React.ReactNode;
-};
+  setOpenModal: (open: boolean) => void;
+  openModal: boolean;
+}
 
-const ModalComp: React.FC<ModalProps> = ({ onClose, children }) => {
-  useEffect(() => {
-    const handleOutsideClick = (event: MouseEvent) => {
-      if (!(event.target as HTMLElement).closest(".modal-content")) {
-        onClose();
-      }
-    };
-
-    document.addEventListener("mousedown", handleOutsideClick);
-
-    return () => {
-      document.removeEventListener("mousedown", handleOutsideClick);
-    };
-  }, [onClose]);
-
+const ModalComp: React.FC<ModalCompProps> = ({
+  children,
+  openModal,
+  setOpenModal,
+}) => {
   return (
-    <div className="fixed inset-0 flex items-center justify-center z-50">
-      <div className="fixed inset-0 bg-black opacity-50"></div>
-      <div className="absolute bg-white rounded-lg shadow-lg p-6 modal-content">
-        {children}
-      </div>
+    <div>
+      <Modal
+        dismissible
+        show={openModal}
+        size="3xl"
+        onClose={() => setOpenModal(false)}
+      >
+        <Modal.Header>Property Details</Modal.Header>
+        <Modal.Body>
+          <div>{children}</div>
+        </Modal.Body>
+      </Modal>
     </div>
   );
 };

--- a/frontend/app/ui/ModalComp.tsx
+++ b/frontend/app/ui/ModalComp.tsx
@@ -8,22 +8,26 @@ interface ModalCompProps {
   children: React.ReactNode;
   setOpenModal: (open: boolean) => void;
   openModal: boolean;
+  modalHeader: string;
+  modalSize: string;
 }
 
 const ModalComp: React.FC<ModalCompProps> = ({
   children,
   openModal,
   setOpenModal,
+  modalHeader,
+  modalSize,
 }) => {
   return (
     <div>
       <Modal
         dismissible
         show={openModal}
-        size="3xl"
+        size={modalSize}
         onClose={() => setOpenModal(false)}
       >
-        <Modal.Header>Property Details</Modal.Header>
+        <Modal.Header>{modalHeader}</Modal.Header>
         <Modal.Body>
           <div>{children}</div>
         </Modal.Body>

--- a/frontend/app/ui/PropertyCard.tsx
+++ b/frontend/app/ui/PropertyCard.tsx
@@ -3,10 +3,10 @@
 import React from "react";
 import { Card, List } from "flowbite-react";
 import Image from "next/image";
-import { CardData } from "./CardData";
+import { PropertyData } from "./CardData";
 
 interface PropertyCardProps {
-  data: CardData;
+  data: PropertyData;
 }
 
 const formatter = new Intl.NumberFormat("en-US", {
@@ -18,17 +18,7 @@ const PropertyCard: React.FC<PropertyCardProps> = ({ data }) => {
   //console.log(data);
   return (
     <div className="w-auto 2xl:w-96">
-      <Card
-        className=""
-        renderImage={() => (
-          <Image
-            width={500}
-            height={500}
-            src={data.image}
-            alt="Property Image 1"
-          />
-        )}
-      >
+      <Card imgAlt="Main Property Image" imgSrc={data.image}>
         <h5 className="text-center text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
           {formatter.format(data.value)}
         </h5>
@@ -45,7 +35,7 @@ const PropertyCard: React.FC<PropertyCardProps> = ({ data }) => {
           </List.Item>
         </List>
         <p className="text-center font-normal text-gray-700 dark:text-gray-400">
-          {data.street}, {data.city}, {data.state}, {data.zip}
+          {data.street1}, {data.city}, {data.state}, {data.zip}
         </p>
       </Card>
     </div>

--- a/frontend/app/ui/PropertyDetail.tsx
+++ b/frontend/app/ui/PropertyDetail.tsx
@@ -30,7 +30,10 @@ const PropertyDetail: React.FC<PropertyDetailProps> = ({ data }) => {
           <div className="mt-4 mb-4">
             <div className="flex justify-between">
               <div className="order-2">
-                <BuySellButtons bsTotals={buySell} />
+                <BuySellButtons
+                  bsTotals={buySell}
+                  tokenPrice={data.tokenPrice}
+                />
               </div>
               <div className="flex flex-col justify-center">
                 <div className="flex justify-between">

--- a/frontend/app/ui/PropertyDetail.tsx
+++ b/frontend/app/ui/PropertyDetail.tsx
@@ -65,22 +65,22 @@ const PropertyDetail: React.FC<PropertyDetailProps> = ({ data }) => {
         </li>
         <li>
           <div className="grid grid-cols-3 mt-4 mb-4 gap-4">
-            <div className="bg-gray-800 border-2 border-gray-400 text-center font-bold">
+            <div className="flex justify-center items-center bg-gray-800 border-2 border-gray-400 text-center font-bold">
               {data.propSubtype} {data.propType}
             </div>
-            <div className="bg-gray-800 border-2 border-gray-400 text-center font-bold">
+            <div className="flex justify-center items-center bg-gray-800 border-2 border-gray-400 text-center font-bold">
               {data.size} sqft
             </div>
-            <div className="bg-gray-800 border-2 border-gray-400 text-center font-bold">
+            <div className="flex justify-center items-center bg-gray-800 border-2 border-gray-400 text-center font-bold">
               {formatter.format(data.sizeValue)}/sqft
             </div>
-            <div className="bg-gray-800 border-2 border-gray-400 text-center font-bold">
+            <div className="flex justify-center items-center bg-gray-800 border-2 border-gray-400 text-center font-bold">
               Built in {data.year}
             </div>
-            <div className="bg-gray-800 border-2 border-gray-400 text-center font-bold">
+            <div className="flex justify-center items-center bg-gray-800 border-2 border-gray-400 text-center font-bold">
               {formatter.format(data.expense)} Expenses/year
             </div>
-            <div className="bg-gray-800 border-2 border-gray-400 text-center font-bold">
+            <div className="flex justify-center items-center bg-gray-800 border-2 border-gray-400 text-center font-bold">
               {formatter.format(data.income)} Income/year
             </div>
           </div>

--- a/frontend/app/ui/PropertyDetail.tsx
+++ b/frontend/app/ui/PropertyDetail.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { PropertyData } from "./CardData";
+import { PropertyData, BuySellData } from "./CardData";
 import GalleryComp from "@/app/ui/GalleryComp";
+import BuySellButtons from "./BuySellButtons";
 
 interface PropertyDetailProps {
   data: PropertyData;
@@ -12,6 +13,11 @@ const formatter = new Intl.NumberFormat("en-US", {
 });
 
 const PropertyDetail: React.FC<PropertyDetailProps> = ({ data }) => {
+  const buySell: BuySellData = {
+    sellTotal: 10,
+    buyTotal: data.tokenForSale,
+  };
+
   return (
     <div className="flex">
       <ul className="divide-y divide-gray-200 dark:divide-gray-700">
@@ -23,8 +29,10 @@ const PropertyDetail: React.FC<PropertyDetailProps> = ({ data }) => {
         <li>
           <div className="mt-4 mb-4">
             <div className="flex justify-between">
-              <div className="order-2">button</div>
-              <div className="flex flex-col">
+              <div className="order-2">
+                <BuySellButtons bsTotals={buySell} />
+              </div>
+              <div className="flex flex-col justify-center">
                 <div className="flex justify-between">
                   <h5 className="text-start text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
                     {formatter.format(data.value)}

--- a/frontend/app/ui/PropertyDetail.tsx
+++ b/frontend/app/ui/PropertyDetail.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { PropertyData } from "./CardData";
+import GalleryComp from "@/app/ui/GalleryComp";
+
+interface PropertyDetailProps {
+  data: PropertyData;
+}
+
+const formatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+const PropertyDetail: React.FC<PropertyDetailProps> = ({ data }) => {
+  return (
+    <div className="flex">
+      <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+        <li>
+          <div className="mb-4">
+            <GalleryComp data={data} />
+          </div>
+        </li>
+        <li>
+          <div className="mt-4 mb-4">
+            <div className="flex justify-between">
+              <div className="order-2">button</div>
+              <div className="flex flex-col">
+                <div className="flex justify-between">
+                  <h5 className="text-start text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+                    {formatter.format(data.value)}
+                  </h5>
+                </div>
+                <h5 className="text-start text-lg font-bold tracking-tight text-gray-600 dark:text-gray-400">
+                  {data.street1}, {data.city}, {data.state}, {data.zip}
+                </h5>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li>
+          <div className="flex flex-col mt-4 mb-4">
+            <div className="grid grid-cols-3">
+              <h5 className="text-start text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+                {data.tokenForSale}
+              </h5>
+              <h5 className="text-start text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+                {data.tokens}
+              </h5>
+              <h5 className="text-start text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+                {formatter.format(data.tokenPrice)}
+              </h5>
+            </div>
+            <div className="grid grid-cols-3">
+              <h5 className="text-start text-lg font-bold tracking-tight text-gray-600 dark:text-gray-400">
+                Tokens For Sale
+              </h5>
+              <h5 className="text-start text-lg font-bold tracking-tight text-gray-600 dark:text-gray-400">
+                Total Tokens
+              </h5>
+              <h5 className="text-start text-lg font-bold tracking-tight text-gray-600 dark:text-gray-400">
+                Price Per Token
+              </h5>
+            </div>
+          </div>
+        </li>
+        <li>
+          <div className="grid grid-cols-3 mt-4 mb-4 gap-4">
+            <div className="bg-gray-800 border-2 border-gray-400 text-center font-bold">
+              {data.propSubtype} {data.propType}
+            </div>
+            <div className="bg-gray-800 border-2 border-gray-400 text-center font-bold">
+              {data.size} sqft
+            </div>
+            <div className="bg-gray-800 border-2 border-gray-400 text-center font-bold">
+              {formatter.format(data.sizeValue)}/sqft
+            </div>
+            <div className="bg-gray-800 border-2 border-gray-400 text-center font-bold">
+              Built in {data.year}
+            </div>
+            <div className="bg-gray-800 border-2 border-gray-400 text-center font-bold">
+              {formatter.format(data.expense)} Expenses/year
+            </div>
+            <div className="bg-gray-800 border-2 border-gray-400 text-center font-bold">
+              {formatter.format(data.income)} Income/year
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div>
+  );
+};
+
+export default PropertyDetail;

--- a/frontend/app/ui/SearchNav.tsx
+++ b/frontend/app/ui/SearchNav.tsx
@@ -22,7 +22,7 @@ const SearchNav: React.FC<SearchBarProps> = ({ per_Page, totalProperties }) => {
       {/* Left */}
       <form onSubmit={handleSubmit} className="flex items-center">
         <label className="mb-2 text-sm font-medium text-gray-900 sr-only dark:text-white">
-          Your Email
+          Search Bar
         </label>
         <div className="relative w-96">
           <input

--- a/frontend/app/ui/SearchNav.tsx
+++ b/frontend/app/ui/SearchNav.tsx
@@ -6,9 +6,14 @@ import React, { useState, ChangeEvent, FormEventHandler } from "react";
 interface SearchBarProps {
   per_Page: number;
   totalProperties: number;
+  search: boolean;
 }
 
-const SearchNav: React.FC<SearchBarProps> = ({ per_Page, totalProperties }) => {
+const SearchNav: React.FC<SearchBarProps> = ({
+  per_Page,
+  totalProperties,
+  search,
+}) => {
   const router = useRouter();
   const handleSubmit: FormEventHandler<HTMLFormElement> = async (e) => {
     e.preventDefault();
@@ -20,40 +25,42 @@ const SearchNav: React.FC<SearchBarProps> = ({ per_Page, totalProperties }) => {
   return (
     <div className="flex justify-between items-center fixed bottom-0 w-full h-16 bg-white border-t border-gray-200 dark:bg-gray-800 dark:border-gray-700 px-4">
       {/* Left */}
-      <form onSubmit={handleSubmit} className="flex items-center">
-        <label className="mb-2 text-sm font-medium text-gray-900 sr-only dark:text-white">
-          Search Bar
-        </label>
-        <div className="relative w-96">
-          <input
-            type="search"
-            id="search"
-            className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5  dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
-            placeholder="Address, Neighborhood, City, ZIP"
-          />
-          <button
-            type="submit"
-            className="absolute top-0 end-0 p-2.5 text-sm font-medium h-full text-white bg-blue-700 rounded-e-lg border border-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
-          >
-            <svg
-              className="w-4 h-4"
-              aria-hidden="true"
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 20 20"
+      {search && (
+        <form onSubmit={handleSubmit} className="flex items-center">
+          <label className="mb-2 text-sm font-medium text-gray-900 sr-only dark:text-white">
+            Search Bar
+          </label>
+          <div className="relative w-96">
+            <input
+              type="search"
+              id="search"
+              className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5  dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+              placeholder="Address, Neighborhood, City, ZIP"
+            />
+            <button
+              type="submit"
+              className="absolute top-0 end-0 p-2.5 text-sm font-medium h-full text-white bg-blue-700 rounded-e-lg border border-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
             >
-              <path
-                stroke="currentColor"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"
-              />
-            </svg>
-            <span className="sr-only">Search</span>
-          </button>
-        </div>
-      </form>
+              <svg
+                className="w-4 h-4"
+                aria-hidden="true"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 20 20"
+              >
+                <path
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"
+                />
+              </svg>
+              <span className="sr-only">Search</span>
+            </button>
+          </div>
+        </form>
+      )}
 
       {/* Center */}
       <div className="flex-grow flex justify-center">

--- a/frontend/app/ui/UserDropdown.tsx
+++ b/frontend/app/ui/UserDropdown.tsx
@@ -58,7 +58,7 @@ const UserDropdown: React.FC = () => {
           >
             <li>
               <Link
-                href="#"
+                href={`/user/${session?.user?.name}/properties`}
                 onClick={closeDropdown}
                 className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
               >

--- a/frontend/app/ui/UserSidebar.tsx
+++ b/frontend/app/ui/UserSidebar.tsx
@@ -10,27 +10,38 @@ import {
   HiUser,
   HiViewBoards,
 } from "react-icons/hi";
+import { useSession } from "next-auth/react";
 
 function UserSidebar() {
+  const { data: session } = useSession();
   return (
     <Sidebar aria-label="User Sidebar" className="justify-start">
       <Sidebar.Items>
         <Sidebar.ItemGroup>
           <Sidebar.Item
-            href="/user/[id]/settings/email"
+            href={`/user/${session?.user?.name}/settings/email`}
             icon={HiShieldExclamation}
           >
             Change Email
           </Sidebar.Item>
-          <Sidebar.Item href="/user/[id]/settings/password" icon={HiViewBoards}>
+          <Sidebar.Item
+            href={`/user/${session?.user?.name}/settings/password`}
+            icon={HiViewBoards}
+          >
             Change Password
           </Sidebar.Item>
-          <Sidebar.Item href="/user/[id]/settings/username" icon={HiUser}>
+          <Sidebar.Item
+            href={`/user/${session?.user?.name}/settings/username`}
+            icon={HiUser}
+          >
             Change Username
           </Sidebar.Item>
         </Sidebar.ItemGroup>
         <Sidebar.ItemGroup>
-          <Sidebar.Item href="#" icon={HiOfficeBuilding}>
+          <Sidebar.Item
+            href={`/user/${session?.user?.name}/properties`}
+            icon={HiOfficeBuilding}
+          >
             Properties
           </Sidebar.Item>
           <Sidebar.Item href="/property/tokenize" icon={HiCurrencyDollar}>

--- a/frontend/app/user/[id]/properties/page.tsx
+++ b/frontend/app/user/[id]/properties/page.tsx
@@ -4,6 +4,7 @@ import PropertyCard from "@/app/ui/PropertyCard";
 import SearchNav from "@/app/ui/SearchNav";
 import ModalComp from "@/app/ui/ModalComp";
 import PropertyDetail from "@/app/ui/PropertyDetail";
+import UserSidebar from "@/app/ui/UserSidebar";
 
 interface SearchResultProps {
   searchParams: { [key: string]: string | string[] | undefined };
@@ -62,34 +63,38 @@ const SearchResult: React.FC<SearchResultProps> = ({ searchParams }) => {
   const end = start + per_page;
 
   const entries = cardDataArray.slice(start, end);
-
-  const search = true;
+  const search = false;
 
   return (
-    <div>
+    <div className="flex">
       <SearchNav
         search={search}
         per_Page={per_page}
         totalProperties={totalProperties}
       />
-      <div className="flex justify-center mt-4 mb-24">
-        <div className="w-full">
-          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 max-w-screen-xl mx-auto mt-8">
-            {entries.map((property, index) => (
-              <div key={property.id} className="p-2 overflow-x-hidden">
-                <button onClick={() => handleOpenModal(index)}>
-                  <PropertyCard data={property} />
-                </button>
-                <ModalComp
-                  openModal={openModals[index]}
-                  setOpenModal={() => handleCloseModal(index)}
-                  modalHeader={modalHeader}
-                  modalSize="3xl"
-                >
-                  <PropertyDetail data={property} />
-                </ModalComp>
-              </div>
-            ))}
+      <div className="h-96 mt-4">
+        <UserSidebar />
+      </div>
+      <div className="ml-10">
+        <div className="flex justify-center mt-4 mb-24">
+          <div className="w-full">
+            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 max-w-screen-xl mx-auto mt-8">
+              {entries.map((property, index) => (
+                <div key={property.id} className="p-2 overflow-x-hidden">
+                  <button onClick={() => handleOpenModal(index)}>
+                    <PropertyCard data={property} />
+                  </button>
+                  <ModalComp
+                    openModal={openModals[index]}
+                    setOpenModal={() => handleCloseModal(index)}
+                    modalHeader={modalHeader}
+                    modalSize="3xl"
+                  >
+                    <PropertyDetail data={property} />
+                  </ModalComp>
+                </div>
+              ))}
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/app/user/[id]/settings/email/page.tsx
+++ b/frontend/app/user/[id]/settings/email/page.tsx
@@ -4,8 +4,8 @@ import React from "react";
 
 const Settings = () => {
   return (
-    <div className="flex justify-center">
-      <UserSidebar />{" "}
+    <div className="flex justify-center mt-4">
+      <UserSidebar />
       <div className="flex-1 justify-center items-center h-screen ml-10 mt-10">
         <ChangeEmail />
       </div>


### PR DESCRIPTION
Added the property details view. Click on a property card to view a modal that details the property. Cards are located in the carousel, the search page, and in the user profile for properties / token management. The sell / buy buttons should bring up a new modal that will ask the user to input a number of tokens. Backend functionality hasn't been integrated in yet so you states are all static and nothing will change when you confirm buy / sell.